### PR TITLE
Fix index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,7 @@ class PaperOnboardingContainer extends Component {
     const { screens } = this.props;
     Animated.timing(
       backgroundAnimation,
-      { toValue: 1, duration: 900 },
+      { toValue: 1, duration: 900, useNativeDriver: false },
     ).start(() => {
       backgroundAnimation.setValue(0);
       this.nextBackground = screens[currentScreen].backgroundColor;


### PR DESCRIPTION
This change adds a parameter required by the Animated in the React Native library and resolves this error warning: "WARN  Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`"